### PR TITLE
fixed deployment for `mainnet`

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -70,8 +70,15 @@ jobs:
           TOKEN: ${{ inputs.token }}
           DURATION: ${{ inputs.duration }}
           HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: false
-      - name: Get contract address
+      - name: Get sepolia contract address
+        if: ${{ inputs.network == 'sepolia' }}
         run: |
           ADDRESS=$(jq -r '."Deployment#Raffle"' ignition/deployments/chain-11155111/deployed_addresses.json)
           echo '# Raffle deployed! 🚀' >> $GITHUB_STEP_SUMMARY
           echo "Address: <a href=\"https://sepolia.etherscan.io/address/$ADDRESS\">$ADDRESS</a>" >> $GITHUB_STEP_SUMMARY
+      - name: Get mainnet contract address
+        if: ${{ inputs.network }} == 'mainnet'
+        run: |
+          ADDRESS=$(jq -r '."Deployment#Raffle"' ignition/deployments/chain-1/deployed_addresses.json)
+          echo '# Raffle deployed! 🚀' >> $GITHUB_STEP_SUMMARY
+          echo "Address: <a href=\"https://etherscan.io/address/$ADDRESS\">$ADDRESS</a>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -54,14 +54,16 @@ jobs:
       - name: Install variables
         run: |
           npx hardhat vars set ALCHEMY_API_KEY "$ALCHEMY_API_KEY"
-          npx hardhat vars set SEPOLIA_PRIVATE_KEY "$SEPOLIA_PRIVATE_KEY"
-          npx hardhat vars set MAINNET_PRIVATE_KEY "$MAINNET_PRIVATE_KEY"
           npx hardhat vars set ETHERSCAN_API_KEY "$ETHERSCAN_API_KEY"
         env:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-          SEPOLIA_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
-          MAINNET_PRIVATE_KEY: ${{ secrets.MAINNET_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+      - name: Set sepolia private key
+        if: ${{ inputs.network == 'sepolia' }}
+        run: npx hardhat vars set PRIVATE_KEY ${{ secrets.SEPOLIA_PRIVATE_KEY }}
+      - name: Set mainnet private key
+        if: ${{ inputs.network == 'mainnet' }}
+        run: npx hardhat vars set PRIVATE_KEY ${{ secrets.MAINNET_PRIVATE_KEY }}
 
       - name: Run deployment script
         run: npx hardhat ignition deploy ignition/modules/Raffle.ts --network ${{ inputs.network }} --verify


### PR DESCRIPTION
Fixed deployment for mainnet throwing an error when fetching the deployed address

This pull request updates the deployment workflow to handle network-specific configurations for the Sepolia and Mainnet networks. The most important changes include separating the private key settings and contract address retrieval based on the network.

Network-specific configurations:

* [`.github/workflows/deploy-contract.yml`](diffhunk://#diff-ef34c2b3201baf80b0cf279d76dfcc7b9171220d69eb1df1d9bd8b0b2e257145L57-R66): Removed the setting of `SEPOLIA_PRIVATE_KEY` and `MAINNET_PRIVATE_KEY` from the general environment variables and added separate steps to set the private key based on the selected network.
* [`.github/workflows/deploy-contract.yml`](diffhunk://#diff-ef34c2b3201baf80b0cf279d76dfcc7b9171220d69eb1df1d9bd8b0b2e257145L73-R86): Added steps to retrieve and log the contract address specifically for the Sepolia and Mainnet networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the deployment workflow by separating private key handling for different networks (Sepolia and Mainnet).
	- Enhanced clarity in the retrieval of contract addresses based on the specified network, with links to Etherscan for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->