### PR TITLE
fixed invalid private key name being setup

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -53,18 +53,14 @@ jobs:
         run: npm ci
       - name: Install variables
         run: |
-          npx hardhat vars set ALCHEMY_API_KEY "$ALCHEMY_API_KEY"
-          npx hardhat vars set ETHERSCAN_API_KEY "$ETHERSCAN_API_KEY"
-        env:
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          npx hardhat vars set ALCHEMY_API_KEY ${{ secrets.ALCHEMY_API_KEY }}
+          npx hardhat vars set ETHERSCAN_API_KEY ${{ secrets.ETHERSCAN_API_KEY }}
       - name: Set sepolia private key
         if: ${{ inputs.network == 'sepolia' }}
-        run: npx hardhat vars set PRIVATE_KEY ${{ secrets.SEPOLIA_PRIVATE_KEY }}
+        run: npx hardhat vars set SEPOLIA_PRIVATE_KEY ${{ secrets.SEPOLIA_PRIVATE_KEY }}
       - name: Set mainnet private key
         if: ${{ inputs.network == 'mainnet' }}
-        run: npx hardhat vars set PRIVATE_KEY ${{ secrets.MAINNET_PRIVATE_KEY }}
-
+        run: npx hardhat vars set MAINNET_PRIVATE_KEY ${{ secrets.MAINNET_PRIVATE_KEY }}
       - name: Run deployment script
         run: npx hardhat ignition deploy ignition/modules/Raffle.ts --network ${{ inputs.network }} --verify
         env:
@@ -79,7 +75,7 @@ jobs:
           echo '# Raffle deployed! 🚀' >> $GITHUB_STEP_SUMMARY
           echo "Address: <a href=\"https://sepolia.etherscan.io/address/$ADDRESS\">$ADDRESS</a>" >> $GITHUB_STEP_SUMMARY
       - name: Get mainnet contract address
-        if: ${{ inputs.network }} == 'mainnet'
+        if: ${{ inputs.network == 'mainnet' }}
         run: |
           ADDRESS=$(jq -r '."Deployment#Raffle"' ignition/deployments/chain-1/deployed_addresses.json)
           echo '# Raffle deployed! 🚀' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request includes updates to the deployment workflow in the `.github/workflows/deploy-contract.yml` file to improve the handling of environment variables and conditional statements.

Improvements to environment variable handling:

* Consolidated the setting of `ALCHEMY_API_KEY` and `ETHERSCAN_API_KEY` to use GitHub secrets directly in the `npx hardhat vars set` commands. (`.github/workflows/deploy-contract.yml`, [.github/workflows/deploy-contract.ymlL56-R63](diffhunk://#diff-ef34c2b3201baf80b0cf279d76dfcc7b9171220d69eb1df1d9bd8b0b2e257145L56-R63))
* Updated the commands for setting the `SEPOLIA_PRIVATE_KEY` and `MAINNET_PRIVATE_KEY` to use the correct variable names. (`.github/workflows/deploy-contract.yml`, [.github/workflows/deploy-contract.ymlL56-R63](diffhunk://#diff-ef34c2b3201baf80b0cf279d76dfcc7b9171220d69eb1df1d9bd8b0b2e257145L56-R63))

Improvements to conditional statements:

* Fixed the conditional statement for checking if the network is `mainnet` by correcting the syntax. (`.github/workflows/deploy-contract.yml`, [.github/workflows/deploy-contract.ymlL82-R78](diffhunk://#diff-ef34c2b3201baf80b0cf279d76dfcc7b9171220d69eb1df1d9bd8b0b2e257145L82-R78))