### PR TITLE
Increased tickets sold per bundle

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -55,9 +55,9 @@ contract Raffle {
         token = _token;
         uint ticketPrice = _ticketPrice * (10 ** token.decimals());
 
-        smallBundle = Bundle(1, ticketPrice);
-        mediumBundle = Bundle(10, ticketPrice * 8);
-        largeBundle = Bundle(100, ticketPrice * 60);
+        smallBundle = Bundle(45, ticketPrice);
+        mediumBundle = Bundle(200, ticketPrice * 3);
+        largeBundle = Bundle(660, ticketPrice * 5);
     }
 
     /// Utility method used to buy any given amount of tickets

--- a/test/Raffle.ts
+++ b/test/Raffle.ts
@@ -8,8 +8,12 @@ import hre from "hardhat";
 import { Raffle } from "../typechain-types";
 
 describe("Raffle", function () {
-  const PRICE_MEDIUM_BUNDLE_MULTIPLIER = 8n;
-  const PRICE_LARGE_BUNDLE_MULTIPLIER = 60n;
+  const PRICE_MEDIUM_BUNDLE_MULTIPLIER = 3n;
+  const PRICE_LARGE_BUNDLE_MULTIPLIER = 5n;
+
+  const SMALL_BUNDLE_AMOUNT = 45n;
+  const MEDIUM_BUNDLE_AMOUNT = 200n;
+  const LARGE_BUNDLE_AMOUNT = 660n;
 
   async function deployRaffleFixture() {
     const ticketPrice = 2n;
@@ -76,7 +80,7 @@ describe("Raffle", function () {
     it("Should set the correct small ticket bundle", async () => {
       const { raffle, ticketPrice } = await loadFixture(deployRaffleFixture);
       const bundle = await raffle.smallBundle();
-      expect(bundle.amount).to.equal(1);
+      expect(bundle.amount).to.equal(SMALL_BUNDLE_AMOUNT);
       expect(bundle.price).to.equal(ticketPrice);
     });
 
@@ -87,31 +91,33 @@ describe("Raffle", function () {
       expect(bundle.price).to.equal(
         ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
       );
-      expect(bundle.amount).to.equal(10);
+      expect(bundle.amount).to.equal(MEDIUM_BUNDLE_AMOUNT);
     });
 
     it("Should set the correct large ticket bundle", async () => {
       const { raffle, ticketPrice } = await loadFixture(deployRaffleFixture);
       const bundle = await raffle.largeBundle();
 
-      expect(bundle.price).to.equal(ticketPrice * 60n);
-      expect(bundle.amount).to.equal(100);
+      expect(bundle.price).to.equal(
+        ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER,
+      );
+      expect(bundle.amount).to.equal(LARGE_BUNDLE_AMOUNT);
     });
 
     it("Should set all the bundles correctly", async () => {
       const { raffle, ticketPrice } = await loadFixture(deployRaffleFixture);
       const [small, medium, large] = await raffle.getBundles();
 
-      expect(small.amount).to.equal(1);
+      expect(small.amount).to.equal(SMALL_BUNDLE_AMOUNT);
       expect(small.price).to.equal(ticketPrice);
 
       expect(medium.price).to.equal(
         ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
       );
-      expect(medium.amount).to.equal(10);
+      expect(medium.amount).to.equal(MEDIUM_BUNDLE_AMOUNT);
 
       expect(large.price).to.equal(ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER);
-      expect(large.amount).to.equal(100);
+      expect(large.amount).to.equal(LARGE_BUNDLE_AMOUNT);
     });
 
     it("Should set the pot to 0", async () => {
@@ -156,17 +162,17 @@ describe("Raffle", function () {
       purchase: (contract: Raffle) => Promise<ContractTransactionResponse>;
     }[] = [
       {
-        amount: 1n,
+        amount: SMALL_BUNDLE_AMOUNT,
         multiplier: 1n,
         purchase: (raffle) => raffle.buySmallTicketBundle(),
       },
       {
-        amount: 10n,
+        amount: MEDIUM_BUNDLE_AMOUNT,
         multiplier: PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         purchase: (raffle) => raffle.buyMediumTicketBundle(),
       },
       {
-        amount: 100n,
+        amount: LARGE_BUNDLE_AMOUNT,
         multiplier: PRICE_LARGE_BUNDLE_MULTIPLIER,
         purchase: (raffle) => raffle.buyLargeTicketBundle(),
       },
@@ -271,7 +277,9 @@ describe("Raffle", function () {
           await rafflePlayer2.buySmallTicketBundle();
           await rafflePlayer2.buySmallTicketBundle();
           await rafflePlayer2.buySmallTicketBundle();
-          expect(await rafflePlayer2.tickets(player2)).to.equal(3);
+          expect(await rafflePlayer2.tickets(player2)).to.equal(
+            SMALL_BUNDLE_AMOUNT * 3n,
+          );
         });
 
         it("Should fail if the raffle end date has been reached", async () => {


### PR DESCRIPTION
Increased the amount of tickets sold in a bundle to help both with the randomness algorithm and with making purchasing tickets more attractive.

Current values are:
| Bundle    | Old size | Old price multiplier | New size | New prize multiplier
| -------- | ------- | ------- | ------- | ------- |
| Small | 1 | 1 | 45 | 1 |
| Medium | 10 | 8 | 200 | 3 |
| Large | 100 | 60 | 660 | 5 |

---

This pull request includes changes to the `Raffle` contract and its accompanying tests to update the ticket bundle amounts and their corresponding prices. The most important changes include modifying the bundle amounts and prices in the contract, and updating the test cases to reflect these new values.

Changes to `Raffle` contract:

* [`contracts/Raffle.sol`](diffhunk://#diff-c2d63a028e11f3ebfd9095ef828bce92e24819ca7a0286a99fd392969aa51e69L58-R60): Updated the `smallBundle`, `mediumBundle`, and `largeBundle` amounts and their corresponding prices.

Updates to test cases:

* [`test/Raffle.ts`](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL11-R16): Modified the `PRICE_MEDIUM_BUNDLE_MULTIPLIER` and `PRICE_LARGE_BUNDLE_MULTIPLIER` constants to reflect the new multipliers. Added constants for the new bundle amounts.
* [`test/Raffle.ts`](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL79-R83): Updated the test cases to check the new bundle amounts and prices. [[1]](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL79-R83) [[2]](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL90-R120) [[3]](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL159-R175) [[4]](diffhunk://#diff-c668b5a5442fa28e4d07147ca97eb8732a4b9bb1530f09d417897d4d78d6d13bL274-R282)