### PR TITLE
Added ability to use referrals 👥 when buying a ticket 🎟️

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -103,7 +103,7 @@ contract Raffle {
 
     /// Buy a small bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
-    function buySmallTicketBundle(address referral) external returns (uint) {
+    function buySmallTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(smallBundle);
         if (referral != address(0)) {
             addReferral(referral);
@@ -118,7 +118,7 @@ contract Raffle {
 
     /// Buys a medium bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
-    function buyMediumTicketBundle(address referral) external returns (uint) {
+    function buyMediumTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(mediumBundle);
 
         if (referral != address(0)) {
@@ -134,7 +134,7 @@ contract Raffle {
 
     /// Buy a large bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
-    function buyLargeTicketBundle(address referral) external returns (uint) {
+    function buyLargeTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(largeBundle);
 
         if (referral != address(0)) {

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -95,41 +95,41 @@ contract Raffle {
     }
 
     /// Buy a small bundle of tickets
-    function buySmallTicketBundle() external returns (uint) {
+    function buySmallTicketBundle() public returns (uint) {
         return buyCollectionOfTickets(smallBundle);
     }
 
     /// Buy a small bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
     function buySmallTicketBundleWithReferral(address referral) external returns (uint) {
-        uint receipt = buyCollectionOfTickets(smallBundle);
+        uint receipt = buySmallTicketBundle();
         addReferral(referral);
         return receipt;
     }
 
     /// Buy a medium bundle of tickets
-    function buyMediumTicketBundle() external returns (uint) {
+    function buyMediumTicketBundle() public returns (uint) {
         return buyCollectionOfTickets(mediumBundle);
     }
 
     /// Buys a medium bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
     function buyMediumTicketBundleWithReferral(address referral) external returns (uint) {
-        uint receipt = buyCollectionOfTickets(mediumBundle);
+        uint receipt = buyMediumTicketBundle();
 
         addReferral(referral);
         return receipt;
     }
 
     /// Buys a large bundle of tickets
-    function buyLargeTicketBundle() external returns (uint) {
+    function buyLargeTicketBundle() public returns (uint) {
         return buyCollectionOfTickets(largeBundle);
     }
 
     /// Buy a large bundle of tickets and gives a referral ticket
     /// @param referral Address to give a referral ticket on purchaser
     function buyLargeTicketBundleWithReferral(address referral) external returns (uint) {
-        uint receipt = buyCollectionOfTickets(largeBundle);
+        uint receipt = buyLargeTicketBundle();
 
         addReferral(referral);
         return receipt;

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -65,7 +65,7 @@ contract Raffle {
 
     /// Utility method used to buy any given amount of tickets
     /// @param bundle the bundle that will be purchased
-    function buyCollectionOfTickets(Bundle memory bundle, address referral) private returns (uint) {
+    function buyCollectionOfTickets(Bundle memory bundle) private returns (uint) {
         require(block.timestamp < raffleEndDate, "Raffle is over");
         require(bundle.amount > 0, "Can not buy 0 tickets");
         require(msg.sender != owner, "Owner cannot participate in the Raffle");
@@ -81,9 +81,6 @@ contract Raffle {
         uint playerTickets = tickets[msg.sender];
         tickets[msg.sender] = playerTickets + bundle.amount;
 
-        if (referral != address(0)) {
-            addReferral(referral);
-        }
         return bundle.amount;
     }
 
@@ -99,19 +96,51 @@ contract Raffle {
         tickets[referral] += 1;
     }
 
-    /// Buy an individual ticket
+    /// Buy a small bundle of tickets
+    function buySmallTicketBundle() external returns (uint) {
+        return buyCollectionOfTickets(smallBundle);
+    }
+
+    /// Buy a small bundle of tickets and gives a referral ticket
+    /// @param referral Address to give a referral ticket on purchaser
     function buySmallTicketBundle(address referral) external returns (uint) {
-        return buyCollectionOfTickets(smallBundle, referral);
+        uint receipt = buyCollectionOfTickets(smallBundle);
+        if (referral != address(0)) {
+            addReferral(referral);
+        }
+        return receipt;
     }
 
-    /// Buy a collection of 10 tickets
+    /// Buy a medium bundle of tickets
+    function buyMediumTicketBundle() external returns (uint) {
+        return buyCollectionOfTickets(mediumBundle);
+    }
+
+    /// Buys a medium bundle of tickets and gives a referral ticket
+    /// @param referral Address to give a referral ticket on purchaser
     function buyMediumTicketBundle(address referral) external returns (uint) {
-        return buyCollectionOfTickets(mediumBundle, referral);
+        uint receipt = buyCollectionOfTickets(mediumBundle);
+
+        if (referral != address(0)) {
+            addReferral(referral);
+        }
+        return receipt;
     }
 
-    /// Buy a collection of 100 tickets
+    /// Buys a large bundle of tickets
+    function buyLargeTicketBundle() external returns (uint) {
+        return buyCollectionOfTickets(largeBundle);
+    }
+
+    /// Buy a large bundle of tickets and gives a referral ticket
+    /// @param referral Address to give a referral ticket on purchaser
     function buyLargeTicketBundle(address referral) external returns (uint) {
-        return buyCollectionOfTickets(largeBundle, referral);
+        uint receipt = buyCollectionOfTickets(largeBundle);
+
+        if (referral != address(0)) {
+            addReferral(referral);
+        }
+        return receipt;
     }
 
     /// Returns all the available bundles sorted from smaller to bigger

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -65,7 +65,7 @@ contract Raffle {
 
     /// Utility method used to buy any given amount of tickets
     /// @param bundle the bundle that will be purchased
-    function buyCollectionOfTickets(Bundle memory bundle) private returns (uint) {
+    function buyCollectionOfTickets(Bundle memory bundle, address referral) private returns (uint) {
         require(block.timestamp < raffleEndDate, "Raffle is over");
         require(bundle.amount > 0, "Can not buy 0 tickets");
         require(msg.sender != owner, "Owner cannot participate in the Raffle");
@@ -74,28 +74,44 @@ contract Raffle {
 
         token.transferFrom(msg.sender, address(this), bundle.price);
         pot += bundle.price;
-        uint playerTickets = tickets[msg.sender];
         if (!isPlayer[msg.sender]) {
             isPlayer[msg.sender] = true;
             players.push(msg.sender);
         }
+        uint playerTickets = tickets[msg.sender];
         tickets[msg.sender] = playerTickets + bundle.amount;
+
+        if (referral != address(0)) {
+            addReferral(referral);
+        }
         return bundle.amount;
     }
 
+    /// Gives a ticket to a user who refered this player
+    /// @param referral address of the user to give the referal bonus
+    function addReferral(address referral) private {
+        require(referral != msg.sender, "User can not refer themselves");
+
+        if (!isPlayer[referral]) {
+            isPlayer[referral] = true;
+            players.push(referral);
+        }
+        tickets[referral] += 1;
+    }
+
     /// Buy an individual ticket
-    function buySmallTicketBundle() public returns (uint) {
-        return buyCollectionOfTickets(smallBundle);
+    function buySmallTicketBundle(address referral) public returns (uint) {
+        return buyCollectionOfTickets(smallBundle, referral);
     }
 
     /// Buy a collection of 10 tickets
-    function buyMediumTicketBundle() public returns (uint) {
-        return buyCollectionOfTickets(mediumBundle);
+    function buyMediumTicketBundle(address referral) public returns (uint) {
+        return buyCollectionOfTickets(mediumBundle, referral);
     }
 
     /// Buy a collection of 100 tickets
-    function buyLargeTicketBundle() public returns (uint) {
-        return buyCollectionOfTickets(largeBundle);
+    function buyLargeTicketBundle(address referral) public returns (uint) {
+        return buyCollectionOfTickets(largeBundle, referral);
     }
 
     /// Returns all the available bundles sorted from smaller to bigger

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -86,13 +86,11 @@ contract Raffle {
 
     /// Gives a ticket to a user who refered this player
     /// @param referral address of the user to give the referal bonus
+    /// @dev the referring user must have own a ticket, proving that they are real accounts
     function addReferral(address referral) private {
         require(referral != msg.sender, "User can not refer themselves");
+        require(isPlayer[referral], "Can only refer a user who owns a ticket");
 
-        if (!isPlayer[referral]) {
-            isPlayer[referral] = true;
-            players.push(referral);
-        }
         tickets[referral] += 1;
     }
 

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -103,9 +103,7 @@ contract Raffle {
     /// @param referral Address to give a referral ticket on purchaser
     function buySmallTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(smallBundle);
-        if (referral != address(0)) {
-            addReferral(referral);
-        }
+        addReferral(referral);
         return receipt;
     }
 
@@ -119,9 +117,7 @@ contract Raffle {
     function buyMediumTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(mediumBundle);
 
-        if (referral != address(0)) {
-            addReferral(referral);
-        }
+        addReferral(referral);
         return receipt;
     }
 
@@ -135,9 +131,7 @@ contract Raffle {
     function buyLargeTicketBundleWithReferral(address referral) external returns (uint) {
         uint receipt = buyCollectionOfTickets(largeBundle);
 
-        if (referral != address(0)) {
-            addReferral(referral);
-        }
+        addReferral(referral);
         return receipt;
     }
 

--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -100,17 +100,17 @@ contract Raffle {
     }
 
     /// Buy an individual ticket
-    function buySmallTicketBundle(address referral) public returns (uint) {
+    function buySmallTicketBundle(address referral) external returns (uint) {
         return buyCollectionOfTickets(smallBundle, referral);
     }
 
     /// Buy a collection of 10 tickets
-    function buyMediumTicketBundle(address referral) public returns (uint) {
+    function buyMediumTicketBundle(address referral) external returns (uint) {
         return buyCollectionOfTickets(mediumBundle, referral);
     }
 
     /// Buy a collection of 100 tickets
-    function buyLargeTicketBundle(address referral) public returns (uint) {
+    function buyLargeTicketBundle(address referral) external returns (uint) {
         return buyCollectionOfTickets(largeBundle, referral);
     }
 

--- a/test/Raffle.ts
+++ b/test/Raffle.ts
@@ -15,7 +15,7 @@ describe("Raffle", function () {
   const MEDIUM_BUNDLE_AMOUNT = 200n;
   const LARGE_BUNDLE_AMOUNT = 660n;
 
-  const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+  const NULL_ADDRESS = hre.ethers.ZeroAddress;
 
   async function deployRaffleFixture() {
     const ticketPrice = 2n;

--- a/test/Raffle.ts
+++ b/test/Raffle.ts
@@ -15,6 +15,8 @@ describe("Raffle", function () {
   const MEDIUM_BUNDLE_AMOUNT = 200n;
   const LARGE_BUNDLE_AMOUNT = 660n;
 
+  const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
   async function deployRaffleFixture() {
     const ticketPrice = 2n;
     const unlockDays = 2;
@@ -164,17 +166,17 @@ describe("Raffle", function () {
       {
         amount: SMALL_BUNDLE_AMOUNT,
         multiplier: 1n,
-        purchase: (raffle) => raffle.buySmallTicketBundle(),
+        purchase: (raffle) => raffle.buySmallTicketBundle(NULL_ADDRESS),
       },
       {
         amount: MEDIUM_BUNDLE_AMOUNT,
         multiplier: PRICE_MEDIUM_BUNDLE_MULTIPLIER,
-        purchase: (raffle) => raffle.buyMediumTicketBundle(),
+        purchase: (raffle) => raffle.buyMediumTicketBundle(NULL_ADDRESS),
       },
       {
         amount: LARGE_BUNDLE_AMOUNT,
         multiplier: PRICE_LARGE_BUNDLE_MULTIPLIER,
-        purchase: (raffle) => raffle.buyLargeTicketBundle(),
+        purchase: (raffle) => raffle.buyLargeTicketBundle(NULL_ADDRESS),
       },
     ];
 
@@ -244,7 +246,7 @@ describe("Raffle", function () {
             .connect(player)
             .approve(await raffle.getAddress(), ticketPrice * 2n * multiplier);
           // Buy 1 ticket and verify that the player has 1 ticket
-          await playerRaffle.buySmallTicketBundle();
+          await playerRaffle.buySmallTicketBundle(NULL_ADDRESS);
           const smallBundle = await raffle.smallBundle();
           expect(await playerRaffle.tickets(player)).to.equal(
             smallBundle.amount,
@@ -274,9 +276,9 @@ describe("Raffle", function () {
           await token
             .connect(player2)
             .approve(await raffle.getAddress(), ticketPrice * 3n);
-          await rafflePlayer2.buySmallTicketBundle();
-          await rafflePlayer2.buySmallTicketBundle();
-          await rafflePlayer2.buySmallTicketBundle();
+          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
+          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
+          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
           expect(await rafflePlayer2.tickets(player2)).to.equal(
             SMALL_BUNDLE_AMOUNT * 3n,
           );
@@ -388,7 +390,7 @@ describe("Raffle", function () {
       await token
         .connect(player)
         .approve(rAddress, ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
       raffleInstance = raffle;
     });
 
@@ -446,7 +448,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
 
@@ -466,7 +468,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
 
@@ -487,7 +489,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyLargeTicketBundle();
+      await raffle.connect(player).buyLargeTicketBundle(NULL_ADDRESS);
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER);
 
@@ -512,7 +514,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
       const pot = await raffle.pot();
 
       time.increaseTo(generateDateInTheFuture(10));
@@ -533,7 +535,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
 
       time.increaseTo(generateDateInTheFuture(5));
       const winnerTx = await raffle.connect(owner).finishRaffle(random);
@@ -553,7 +555,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle();
+      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
       const pot = await raffle.pot();
 
       time.increaseTo(generateDateInTheFuture(10));
@@ -589,21 +591,21 @@ describe("Raffle", function () {
         await token
           .connect(player1)
           .approve(await raffle.getAddress(), ticketCost);
-        await raffle.connect(player1).buyMediumTicketBundle(); // 1 ticket
+        await raffle.connect(player1).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
 
         // Player 2
         await token
           .connect(player2)
           .approve(await raffle.getAddress(), ticketCost * 3n);
-        await raffle.connect(player2).buyMediumTicketBundle(); // 1 ticket
-        await raffle.connect(player2).buyMediumTicketBundle(); // Total 2 tickets
-        await raffle.connect(player2).buyMediumTicketBundle(); // Total 3 tickets
+        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
+        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // Total 2 tickets
+        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // Total 3 tickets
 
         // Player 3
         await token
           .connect(player3)
           .approve(await raffle.getAddress(), ticketCost);
-        await raffle.connect(player3).buyMediumTicketBundle(); // 1 ticket
+        await raffle.connect(player3).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
 
         // Simulate new block for randomness
         await hre.network.provider.send("evm_increaseTime", [

--- a/test/Raffle.ts
+++ b/test/Raffle.ts
@@ -15,8 +15,6 @@ describe("Raffle", function () {
   const MEDIUM_BUNDLE_AMOUNT = 200n;
   const LARGE_BUNDLE_AMOUNT = 660n;
 
-  const NULL_ADDRESS = hre.ethers.ZeroAddress;
-
   async function deployRaffleFixture() {
     const ticketPrice = 2n;
     const unlockDays = 2;
@@ -169,20 +167,26 @@ describe("Raffle", function () {
       {
         amount: SMALL_BUNDLE_AMOUNT,
         multiplier: 1n,
-        purchase: (raffle, referral = NULL_ADDRESS) =>
-          raffle.buySmallTicketBundle(referral),
+        purchase: (raffle, referral) =>
+          referral
+            ? raffle.buySmallTicketBundleWithReferral(referral)
+            : raffle.buySmallTicketBundle(),
       },
       {
         amount: MEDIUM_BUNDLE_AMOUNT,
         multiplier: PRICE_MEDIUM_BUNDLE_MULTIPLIER,
-        purchase: (raffle, referral = NULL_ADDRESS) =>
-          raffle.buyMediumTicketBundle(referral),
+        purchase: (raffle, referral) =>
+          referral
+            ? raffle.buyMediumTicketBundleWithReferral(referral)
+            : raffle.buyMediumTicketBundle(),
       },
       {
         amount: LARGE_BUNDLE_AMOUNT,
         multiplier: PRICE_LARGE_BUNDLE_MULTIPLIER,
-        purchase: (raffle, referral = NULL_ADDRESS) =>
-          raffle.buyLargeTicketBundle(referral),
+        purchase: (raffle, referral) =>
+          referral
+            ? raffle.buyLargeTicketBundleWithReferral(referral)
+            : raffle.buyLargeTicketBundle(),
       },
     ];
 
@@ -252,7 +256,7 @@ describe("Raffle", function () {
             .connect(player)
             .approve(await raffle.getAddress(), ticketPrice * 2n * multiplier);
           // Buy 1 ticket and verify that the player has 1 ticket
-          await playerRaffle.buySmallTicketBundle(NULL_ADDRESS);
+          await playerRaffle.buySmallTicketBundle();
           const smallBundle = await raffle.smallBundle();
           expect(await playerRaffle.tickets(player)).to.equal(
             smallBundle.amount,
@@ -282,9 +286,9 @@ describe("Raffle", function () {
           await token
             .connect(player2)
             .approve(await raffle.getAddress(), ticketPrice * 3n);
-          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
-          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
-          await rafflePlayer2.buySmallTicketBundle(NULL_ADDRESS);
+          await rafflePlayer2.buySmallTicketBundle();
+          await rafflePlayer2.buySmallTicketBundle();
+          await rafflePlayer2.buySmallTicketBundle();
           expect(await rafflePlayer2.tickets(player2)).to.equal(
             SMALL_BUNDLE_AMOUNT * 3n,
           );
@@ -423,7 +427,7 @@ describe("Raffle", function () {
       await token
         .connect(player)
         .approve(rAddress, ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
       raffleInstance = raffle;
     });
 
@@ -481,7 +485,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
 
@@ -501,7 +505,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER);
 
@@ -522,7 +526,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyLargeTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyLargeTicketBundle();
       const pot = await raffle.pot();
       expect(pot).to.equal(ticketPrice * PRICE_LARGE_BUNDLE_MULTIPLIER);
 
@@ -547,7 +551,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
       const pot = await raffle.pot();
 
       time.increaseTo(generateDateInTheFuture(10));
@@ -568,7 +572,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
 
       time.increaseTo(generateDateInTheFuture(5));
       const winnerTx = await raffle.connect(owner).finishRaffle(random);
@@ -588,7 +592,7 @@ describe("Raffle", function () {
           await raffle.getAddress(),
           ticketPrice * PRICE_MEDIUM_BUNDLE_MULTIPLIER,
         );
-      await raffle.connect(player).buyMediumTicketBundle(NULL_ADDRESS);
+      await raffle.connect(player).buyMediumTicketBundle();
       const pot = await raffle.pot();
 
       time.increaseTo(generateDateInTheFuture(10));
@@ -624,21 +628,21 @@ describe("Raffle", function () {
         await token
           .connect(player1)
           .approve(await raffle.getAddress(), ticketCost);
-        await raffle.connect(player1).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
+        await raffle.connect(player1).buyMediumTicketBundle(); // 1 ticket
 
         // Player 2
         await token
           .connect(player2)
           .approve(await raffle.getAddress(), ticketCost * 3n);
-        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
-        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // Total 2 tickets
-        await raffle.connect(player2).buyMediumTicketBundle(NULL_ADDRESS); // Total 3 tickets
+        await raffle.connect(player2).buyMediumTicketBundle(); // 1 ticket
+        await raffle.connect(player2).buyMediumTicketBundle(); // Total 2 tickets
+        await raffle.connect(player2).buyMediumTicketBundle(); // Total 3 tickets
 
         // Player 3
         await token
           .connect(player3)
           .approve(await raffle.getAddress(), ticketCost);
-        await raffle.connect(player3).buyMediumTicketBundle(NULL_ADDRESS); // 1 ticket
+        await raffle.connect(player3).buyMediumTicketBundle(); // 1 ticket
 
         // Simulate new block for randomness
         await hre.network.provider.send("evm_increaseTime", [


### PR DESCRIPTION
Added new methods where users can be referred while buying a ticket.

For a user to be eligible for a referral they must:
- Not be the player who is buying the ticket themselves.
- Already own a ticket (Even if it's a free ticket)

Resolves #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a referral system for ticket purchases, allowing users to specify a referral address when buying tickets.
	- Added functionality to grant free tickets to users who refer others.
	- New ticket purchasing options with referral bonuses for small, medium, and large ticket bundles.

- **Bug Fixes**
	- Ensured that users cannot refer themselves in the referral system.

- **Tests**
	- Updated test cases to include referral functionality and validate the new ticket purchasing process.
	- Added tests to ensure proper handling of allowances and balances with the referral logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->