### PR TITLE
Added event emitted on referral

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -17,6 +17,9 @@ contract Raffle {
     /// Emitted when the raffle is over
     event WinnerPicked(address winner);
 
+    /// Emitted when a user is referred
+    event Referred(address referral);
+
     /// Address of the deployer of the contract.
     /// @notice This is the user that can finalize the raffle and receives the commision
     address private immutable owner;
@@ -82,6 +85,8 @@ contract Raffle {
         require(isPlayer[referral], "Can only refer a user who owns a ticket");
 
         tickets[referral] += 1;
+
+        emit Referred(referral);
     }
 
     /// Buy a small bundle of tickets

--- a/test/Raffle.ts
+++ b/test/Raffle.ts
@@ -341,6 +341,24 @@ describe("Raffle", function () {
           expect(await raffle.connect(referral).tickets(referral)).to.equal(2);
         });
 
+        it("Should emit event on referral", async () => {
+          const { raffle, players, ticketPrice } =
+            await loadFixture(deployRaffleFixture);
+
+          const [player, referral] = players;
+          // We made the referral into a player
+          await raffle.connect(referral).getFreeTicket();
+
+          // We purchase the ticket with the referral
+          const tx = await purchase(
+            raffle.connect(player),
+            ticketPrice * multiplier,
+            referral.address,
+          );
+
+          await expect(tx).to.emit(raffle, "Referred").withArgs(referral);
+        });
+
         it("Should not let user refer itself", async () => {
           const { raffle, players, ticketPrice } =
             await loadFixture(deployRaffleFixture);


### PR DESCRIPTION
This pull request introduces a new event for user referrals in the `Raffle` contract and updates the test suite to verify this functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event `Referred` in the Raffle contract to enhance the referral system.
	- Updated the referral process to ensure only legitimate players can refer others.

- **Tests**
	- Added a test case to verify that the `Referred` event is emitted correctly during ticket purchases using a referral.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->