### PR TITLE
Split verification of contract into new step

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -64,12 +64,20 @@ jobs:
         if: ${{ inputs.network == 'mainnet' }}
         run: npx hardhat vars set MAINNET_PRIVATE_KEY ${{ secrets.MAINNET_PRIVATE_KEY }}
       - name: Run deployment script
-        run: npx hardhat ignition deploy ignition/modules/Raffle.ts --network ${{ inputs.network }} --verify
+        run: npx hardhat ignition deploy ignition/modules/Raffle.ts --network ${{ inputs.network }}
         env:
           PRICE: ${{ inputs.price }}
           DURATION: ${{ inputs.duration }}
           FIXED_PRIZE: ${{ inputs.fixedPrize }}
           HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: false
+      - name: Verify contracts on Etherscan
+        run: |
+          if [ "${{ inputs.network }}" == "sepolia" ]; then
+            npx hardhat ignition verify chain-11155111 --include-unrelated-contracts
+          else
+            npx hardhat ignition verify chain-1 --include-unrelated-contracts
+          fi
+        continue-on-error: true
       - name: Get sepolia contract address
         if: ${{ inputs.network == 'sepolia' }}
         run: |


### PR DESCRIPTION
This pull request updates the deployment workflow for smart contracts, specifically separating the contract verification step from the deployment command. The verification is now handled in a dedicated step after deployment, improving clarity and error handling in the deployment process.

**Deployment workflow improvements:**

* The `--verify` flag has been removed from the deployment command in `.github/workflows/deploy-contract.yml`, so deployment and verification are now two distinct steps.
* A new step has been added to verify contracts on Etherscan after deployment, using the appropriate chain ID for the selected network (`sepolia` or `mainnet`). This step is set to continue on error, so verification failures won't block the workflow.